### PR TITLE
Compute all model dim params based on provided scale + configurable multipliers

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,42 @@
+import pytest
+from pytest import approx
+
+from threedframe.config import _Config
+
+# at 0.69 scale
+computed_vals = [
+    (
+        "support_size",
+        17.53,
+    ),
+    (
+        "core_size",
+        35.56,
+    ),
+    (
+        "fixture_shell_thickness",
+        3.0,
+    ),
+    (
+        "fixture_length",
+        38.1,
+    ),
+    (
+        "fixture_size",
+        20.54,
+    ),
+    (
+        "label_size",
+        6.0,
+    ),
+    (
+        "label_width",
+        9.0,
+    ),
+]
+
+
+@pytest.mark.parametrize("attr,expect", computed_vals)
+def test_config(attr: str, expect: float):
+    c = _Config(SUPPORT_SCALE=0.69)
+    assert getattr(c, attr) == approx(expect, rel=1e-2)

--- a/threedframe/cli.py
+++ b/threedframe/cli.py
@@ -69,11 +69,13 @@ def generate(
         False, "-r", "--render", help="Render mesh.", is_flag=True
     ),
     render_format: Optional[str] = typer.Option("stl", "-f", "--format", help="Render file type."),
+    scale: Optional[float] = typer.Option(1.0, "-s", "--scale", help="Support size scale."),
 ):
     """Generate joint model from given vertices."""
     if not vertices:
         typer.confirm("Are you sure you want to render ALL vertices?", abort=True)
         vertices = None  # indicates all in director params.
+    config.SUPPORT_SCALE = scale
     params = JointDirectorParams(
         model=model_path, vertices=vertices, render=render, render_file_type=render_format
     )

--- a/threedframe/config.py
+++ b/threedframe/config.py
@@ -92,13 +92,45 @@ class _Config(BaseSettings):
             self.setup_libs()
         return self._dotSCAD
 
-    # Model Params
     GAP: float = 0.02  # 3dPrinting fudge factor.
-    CORE_SIZE: float = 1.4 * Constants.INCH
-    SUPPORT_SIZE: float = 0.69 * Constants.INCH
-    FIXTURE_WALL_THICKNESS: float = 6.0
-    FIXTURE_HOLE_SIZE: float = SUPPORT_SIZE + GAP
-    FIXTURE_SIZE: float = FIXTURE_HOLE_SIZE + FIXTURE_WALL_THICKNESS
+
+    # Support dimension scale,
+    SUPPORT_SCALE: float = 1.0
+
+    # Multipliers applied to support size.
+    CORE_SIZE_MULTIPLIER: float = 2.03
+    FIXTURE_SHELL_THICKNESS_MULTIPLIER: float = 0.1712
+    FIXTURE_LENGTH_MULTIPLIER: float = 2.1739
+    LABEL_SIZE_MULTIPLIER: float = 0.34
+    LABEL_WIDTH_MULTIPLIER: float = 0.51
+
+    @property
+    def support_size(self) -> float:
+        return self.SUPPORT_SCALE * Constants.INCH
+
+    @property
+    def core_size(self) -> float:
+        return self.support_size * self.CORE_SIZE_MULTIPLIER
+
+    @property
+    def fixture_shell_thickness(self) -> float:
+        return self.support_size * self.FIXTURE_SHELL_THICKNESS_MULTIPLIER
+
+    @property
+    def fixture_length(self) -> float:
+        return self.support_size * self.FIXTURE_LENGTH_MULTIPLIER
+
+    @property
+    def fixture_size(self) -> float:
+        return (self.support_size + self.GAP) + self.fixture_shell_thickness
+
+    @property
+    def label_size(self) -> float:
+        return self.support_size * self.LABEL_SIZE_MULTIPLIER
+
+    @property
+    def label_width(self) -> float:
+        return self.support_size * self.LABEL_WIDTH_MULTIPLIER
 
 
 config = _Config()

--- a/threedframe/scad/fixture.py
+++ b/threedframe/scad/fixture.py
@@ -33,7 +33,7 @@ class FixtureParams(BaseModel):
 
     @property
     def extrusion_height(self) -> float:
-        return 1.5 * Constants.INCH
+        return config.fixture_length
 
     @property
     def distance_to_origin(self) -> S.Mul:
@@ -106,10 +106,10 @@ class FixtureParams(BaseModel):
 @attr.s(auto_attribs=True)
 class Fixture(FixtureMeta):
     def create_base(self) -> sp.OpenSCADObject:
-        return sp.square(config.FIXTURE_SIZE, center=True)
+        return sp.square(config.fixture_size, center=True)
 
     def do_extrude(self, obj: sp.OpenSCADObject):
-        obj = utils.hollow_out(obj, shell_thickness=3)
+        obj = utils.hollow_out(obj, shell_thickness=config.fixture_shell_thickness)
         obj = sp.linear_extrude(self.params.extrusion_height)(obj)
         return obj
 

--- a/threedframe/scad/label.py
+++ b/threedframe/scad/label.py
@@ -24,8 +24,8 @@ class LabelParams(BaseModel):
     halign: str = "center"
     valign: str = "center"
     depth: float = 1.5
-    size: float = 6
-    width: float = 9
+    size: float = config.label_size
+    width: float = config.label_width
     center: bool = True
 
 
@@ -59,7 +59,7 @@ class FixtureLabel(LabelMeta):
             if gt_optimal and gt_min_area:
                 # ensure the taxicab distance ( Σ{x-dist, y-dist} ) is at least a fixture away.
                 other_boundaries = [
-                    face.centroid_point.taxicab_distance(f) > config.FIXTURE_SIZE
+                    face.centroid_point.taxicab_distance(f) > config.fixture_size
                     for f in other_centers
                 ]
                 logger.info("Fixture label face boundary checks: {}", other_boundaries)


### PR DESCRIPTION
TLDR:
 * Adds a [0-1.0] scale parameter (1.0 == 1 inch).
 * Makes ALL dimension related parameters (core size, fixture dim/length/shell, label size/width, etc.) computed based on calculations on the scale and configurable multiplier values.

Closes #16 since it adds a scale flag that can be used to generate models at _any_ size.

Closes #27 since it adds a multiplier for fixture shell thickness (along with every other related param). This value can be configured to achieve an equivalent shell thickness at any scale.

Closes #8 for the same reason as above (but for core size.)



- feat(config): compute all model params based on new scale param + multipliers
- feat(scad/label): update references to computed properties
- feat(scad/fixture): update references to computed properties
- test(config): add test for asserting scale-based property calculation results
- feat(cli): add scale flag for providing support size scale
