### PR TITLE
Component Build Context for exposing algorithm strategies + flag modifiers, several optimizations

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,21 +33,28 @@ x-3dframe-util: &3dframe-util
     profiles:
         - util
 
+x-3dframe-mcg: &3dframe-mcg
+    <<: *3dframe-defaults
+    image: ghcr.io/arroyodev-llc/threedframe:mcg
+    build:
+        <<: *3dframe-build
+        args:
+            BLENDER_MAJOR: 3.2
+            BLENDER_VERSION: 3.2.1
+            BLENDER_ARCH: linux-x64
+            OPENSCAD_REPO: "https://github.com/parvit/openscad.git"
+            OPENSCAD_REV: "feature_multicore_geometry"
+
+
 services:
     3dframe:
         <<: *3dframe-defaults
 
     3dframe-mcg:
-        <<: *3dframe-defaults
-        image: ghcr.io/arroyodev-llc/threedframe:mcg
-        build:
-            <<: *3dframe-build
-            args:
-                BLENDER_MAJOR: 3.2
-                BLENDER_VERSION: 3.2.1
-                BLENDER_ARCH: linux-x64
-                OPENSCAD_REPO: "https://github.com/parvit/openscad.git"
-                OPENSCAD_REV: "feature_multicore_geometry"
+        <<: *3dframe-mcg
+        entrypoint: ["/docker-entrypoint.sh"]
+        command: ["sleep", "21600"]
+
     shell:
         <<: *3dframe-util
         entrypoint: ["/docker-entrypoint.sh"]

--- a/openscad.conf
+++ b/openscad.conf
@@ -6,11 +6,11 @@ autoReload=true
 
 [feature]
 fast-csg=true
-fast-csg-debug=true
-fast-csg-exact=true
-fast-csg-exact-callbacks=true
+fast-csg-debug=false
+fast-csg-exact=false
+fast-csg-exact-callbacks=false
 fast-csg-remesh=true
-fast-csg-remesh-predictibly=true
+fast-csg-remesh-predictibly=false
 fast-csg-trust-corefinement=true
 import-function=true
 input-driver-dbus=true
@@ -19,10 +19,10 @@ multicore-ops=true
 roof=true
 sort-stl=true
 textmetrics=true
-vertex-object-renderers=true
-vertex-object-renderers-direct=true
-vertex-object-renderers-indexing=true
-vertex-object-renderers-prealloc=true
+vertex-object-renderers=false
+vertex-object-renderers-direct=false
+vertex-object-renderers-indexing=false
+vertex-object-renderers-prealloc=false
 
 [view]
 hide3DViewToolbar=false

--- a/poetry.lock
+++ b/poetry.lock
@@ -2124,9 +2124,9 @@ dev = ["pre-commit (>=2.17.0,<3.0.0)", "flake8 (>=3.8.3,<4.0.0)", "autoflake (>=
 all = ["rich (>=10.11.0,<13.0.0)", "shellingham (>=1.3.0,<2.0.0)", "colorama (>=0.4.3,<0.5.0)"]
 
 [[package]]
-name = "types-attrs"
-version = "19.1.0"
-description = "Typing stubs for attrs"
+name = "types-psutil"
+version = "5.9.5"
+description = "Typing stubs for psutil"
 category = "dev"
 optional = false
 python-versions = "*"
@@ -2312,7 +2312,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.10"
-content-hash = "313fb9f10e737dad869b7f747016ff6873d6e3b944ec0fa9330c30b2af283730"
+content-hash = "ced291c3b2a28d837d4f465e394fa62f33a19c574b20e22f24e4b61916dd9347"
 
 [metadata.files]
 addict = [
@@ -3602,8 +3602,9 @@ typer = [
     {file = "typer-0.6.1-py3-none-any.whl", hash = "sha256:54b19e5df18654070a82f8c2aa1da456a4ac16a2a83e6dcd9f170e291c56338e"},
     {file = "typer-0.6.1.tar.gz", hash = "sha256:2d5720a5e63f73eaf31edaa15f6ab87f35f0690f8ca233017d7d23d743a91d73"},
 ]
-types-attrs = [
-    {file = "types_attrs-19.1.0-py2.py3-none-any.whl", hash = "sha256:d11acf7a2531a7c52a740c30fa3eb8d01d3066c10d34c01ff5e59502caac5352"},
+types-psutil = [
+    {file = "types-psutil-5.9.5.tar.gz", hash = "sha256:bef91de096b77ff7bc3a92bafe466ee55f842286c1d734658b7c26b259078253"},
+    {file = "types_psutil-5.9.5-py3-none-any.whl", hash = "sha256:c188ec98cadbc6d96f4b03e4c1e920195c51590923e7f928be3a6d5810a1d356"},
 ]
 typing-extensions = [
     {file = "typing_extensions-4.3.0-py3-none-any.whl", hash = "sha256:25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ pdbpp = "^0.10.3"
 hypothesis = {version = "^6.13.1", extras = ["cli", "codemods"]}
 ipython = "^8.4.0"
 black = "^22.6.0"
-types-attrs = "^19.1.0"
+types-psutil = "^5.9.5"
 
 
 [tool.poetry.group.test]

--- a/threedframe/models/model.py
+++ b/threedframe/models/model.py
@@ -1,9 +1,12 @@
 """3dframe model models."""
+from __future__ import annotations
+
 import string
 import itertools
-from typing import Dict, List, Tuple, Iterator, Optional
+from typing import Dict, List, Tuple, Union, Iterator, Optional
+from pathlib import Path
 
-from pydantic import Field, BaseModel, validator
+from pydantic import Field, BaseModel, validator, parse_file_as
 
 
 class ModelEdge(BaseModel):
@@ -95,6 +98,19 @@ class ModelData(BaseModel):
         vert = next((v for v in self.vertices.values() if v.label.lower() == label.lower()), None)
         if vert:
             return vert.vidx
+        return None
+
+    @classmethod
+    def from_path(cls, path: Path) -> ModelData:
+        """Parse data from file at path."""
+        return parse_file_as(ModelData, path)
+
+    @classmethod
+    def from_source(cls, source: Union[Path, ModelData]) -> ModelData:
+        """Instantiate ModelData from a given source."""
+        if isinstance(source, cls):
+            return source
+        return cls.from_path(source)
 
 
 ModelVertex.update_forward_refs()

--- a/threedframe/scad/build.py
+++ b/threedframe/scad/build.py
@@ -147,7 +147,6 @@ class JointDirector:
         logger.success("Writing mesh -> {}", out_path)
         proc = utils.openscad_cmd(
             *self.params.render_file_type.scad_args,
-            "--enable=all",
             "-o",
             str(out_path),
             str(self.scad_paths[joint.vertex]),

--- a/threedframe/scad/context.py
+++ b/threedframe/scad/context.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from enum import Flag, auto
+from typing import TYPE_CHECKING, Optional, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    pass
+
+
+class BuildFlag(Flag):
+    CORE = auto()
+    FIXTURES = auto()
+
+    CORE_LABEL = auto()
+    FIXTURE_LABEL = auto()
+
+    LABELS = CORE_LABEL | FIXTURE_LABEL
+
+    JOINT = CORE | FIXTURES | LABELS
+
+
+@runtime_checkable
+class Context(Protocol):
+    context: Optional[Context]
+
+    @property
+    def flags(self) -> BuildFlag:
+        ...
+
+    @classmethod
+    def from_build_context(cls, ctx: Context):
+        ...

--- a/threedframe/scad/context.py
+++ b/threedframe/scad/context.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from enum import Flag, auto
-from typing import TYPE_CHECKING, Optional, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, TypeVar, Optional, Protocol, runtime_checkable
+
+import attrs
 
 if TYPE_CHECKING:
     pass
@@ -19,8 +21,12 @@ class BuildFlag(Flag):
     JOINT = CORE | FIXTURES | LABELS
 
 
+ParamsT = TypeVar("ParamsT", contravariant=True)
+T = TypeVar("T")
+
+
 @runtime_checkable
-class Context(Protocol):
+class Context(Protocol[ParamsT]):
     context: Optional[Context]
 
     @property
@@ -28,5 +34,20 @@ class Context(Protocol):
         ...
 
     @classmethod
-    def from_build_context(cls, ctx: Context):
+    def from_build_context(cls, ctx: Context) -> Context:
         ...
+
+    def build_strategy(self, params: ParamsT) -> T:
+        ...
+
+    def assemble(self, params: ParamsT) -> T:
+        ...
+
+
+@attrs.define
+class BuildContext:
+    build_flags: BuildFlag = attrs.field(default=BuildFlag.JOINT)
+
+    @property
+    def flags(self) -> BuildFlag:
+        return self.build_flags

--- a/threedframe/scad/joint.py
+++ b/threedframe/scad/joint.py
@@ -150,6 +150,8 @@ class Joint(JointMeta):
         _intersecting_fixtures = [_fixtures[k] for k, v in init_intersections.items() if any(v)]
         logger.warning("intersecting fixtures: {}", [f.name for f in _intersecting_fixtures])
 
+        # todo: properly optimize with a set high and binary search.
+        factor = 1.0
         while True:
             intersections = self.find_fixture_intersections(_intersecting_fixtures)
             inter_by_all = [any(ib) for ib in intersections.values()]
@@ -160,8 +162,9 @@ class Joint(JointMeta):
                 fix = _fixtures[fname]
                 if any(intersected_by):
                     logger.warning("[{}] intersected by: {}", fix.name, intersected_by)
-                    fix.extend_fixture_base(1)
+                    fix.extend_fixture_base(1.1 * factor)
                     _fixtures[fix.name] = fix
+            factor += 0.25
 
         return list(_fixtures.values())
 

--- a/threedframe/scad/label.py
+++ b/threedframe/scad/label.py
@@ -16,6 +16,7 @@ from solid.core.object_base import OpenSCADObject
 
 from threedframe import utils
 from threedframe.config import config
+from threedframe.scad.noop import NoOpScad
 from threedframe.scad.context import Context, BuildFlag
 from threedframe.scad.interfaces import LabelMeta, FixtureMeta
 
@@ -37,6 +38,8 @@ class LabelContext(Context["LabelParams"]):
         strategy: LabelMeta = FixtureLabel
         if ctx.flags & BuildFlag.CORE_LABEL:
             strategy = CoreLabel
+        if not ctx.flags & BuildFlag.CORE_LABEL or not ctx.flags & BuildFlag.FIXTURE_LABEL:
+            strategy = NoOpScad
         child_ctx = cls(context=ctx, strategy=strategy)
         return child_ctx
 

--- a/threedframe/scad/label.py
+++ b/threedframe/scad/label.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from enum import IntEnum
-from typing import TYPE_CHECKING, Any, Dict, Union
+from typing import TYPE_CHECKING, Any, Dict, Type, Union
 
 import attrs
 import solid as sp
@@ -24,9 +24,9 @@ if TYPE_CHECKING:
 
 
 @attrs.define
-class LabelContext:
+class LabelContext(Context["LabelParams"]):
     context: Context
-    strategy: LabelMeta
+    strategy: Type[LabelMeta]
 
     @property
     def flags(self) -> BuildFlag:
@@ -39,6 +39,15 @@ class LabelContext:
             strategy = CoreLabel
         child_ctx = cls(context=ctx, strategy=strategy)
         return child_ctx
+
+    def build_strategy(self, params: LabelParams) -> LabelMeta:
+        inst = self.strategy(params=params)
+        return inst
+
+    def assemble(self, params: LabelParams) -> LabelMeta:
+        inst = self.build_strategy(params)
+        inst.assemble()
+        return inst
 
 
 class LabelParams(BaseModel):

--- a/threedframe/scad/label.py
+++ b/threedframe/scad/label.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 from enum import IntEnum
 from typing import TYPE_CHECKING, Any, Dict, Union
 
-import attr
+import attrs
 import solid as sp
 import sympy as S
 import solid.extensions.bosl2 as bosl2
@@ -14,10 +16,29 @@ from solid.core.object_base import OpenSCADObject
 
 from threedframe import utils
 from threedframe.config import config
+from threedframe.scad.context import Context, BuildFlag
 from threedframe.scad.interfaces import LabelMeta, FixtureMeta
 
 if TYPE_CHECKING:
     from pydantic.typing import DictStrAny
+
+
+@attrs.define
+class LabelContext:
+    context: Context
+    strategy: LabelMeta
+
+    @property
+    def flags(self) -> BuildFlag:
+        return self.context.flags
+
+    @classmethod
+    def from_build_context(cls, ctx: Context) -> LabelContext:
+        strategy: LabelMeta = FixtureLabel
+        if ctx.flags & BuildFlag.CORE_LABEL:
+            strategy = CoreLabel
+        child_ctx = cls(context=ctx, strategy=strategy)
+        return child_ctx
 
 
 class LabelParams(BaseModel):
@@ -61,7 +82,7 @@ class FixtureLabelParams(LabelParams):
         return self.target.params.labels_tag
 
 
-@attr.s(auto_attribs=True, kw_only=True)
+@attrs.define(kw_only=True)
 class FixtureLabel(LabelMeta):
     params: FixtureLabelParams
 
@@ -84,7 +105,7 @@ class FixtureLabel(LabelMeta):
         return res(obj)
 
 
-@attr.s(auto_attribs=True, kw_only=True)
+@attrs.define(kw_only=True)
 class CoreLabel(LabelMeta):
     core_data: Dict[str, Any]
 

--- a/threedframe/scad/noop.py
+++ b/threedframe/scad/noop.py
@@ -1,0 +1,19 @@
+from typing import Any
+
+import attrs
+import solid as sp
+
+from threedframe.scad.interfaces import ScadMeta
+
+
+@attrs.define
+class NoOpScad(ScadMeta):
+    context: Any = attrs.field(default=None)
+    params: Any = attrs.field(default=None)
+
+    @property
+    def name(self):
+        return "NOOP"
+
+    def assemble(self):
+        self.scad_object = sp.union()


### PR DESCRIPTION
- feat(scad): add BuildFlag + Context protocol
- feat(models): add ModelData creator helpers, root Build Context
- feat(scad): add LabelContext
- feat(scad): add CoreContext
- feat(scad): add FixtureContext
- feat(scad): update interface attrs, add JointParamsMeta
- feat(scad): add JointContext
- feat(deps): add types deps, remove old attrs types
- feat(scad): make Context generic on scad params, define build_strategy+assemble in protocol
- feat(scad): add core paramters base, make JointParamsBase abstract not proto
- feat(scad): implement assemble in LabelContext
- feat(scad): extract CoreParams, implement CoreContext assemble
- feat(scad): implement FixtureContext assemble, add FixtureMesh container for o3d mesh computations
- feat(scad): implement JointContext assemble, extract JointParams, implement improved multiprocessing routine for generating fixture meshes
- feat(scad): implement DirectorContext, extend params, more
- feat(scad): add NoOp scad
- feat(scad): use noop strategy if labels not in build flags
- feat(openscad): optimize openscad config
- feat(cli): update generate entry to utilize new build contexts
- fix(joint): dirty quick optimization for fixture intersections
- feat(build): update 3dframe-mcg service to sleep for execing instead of respawning
