### PR TITLE
Operational Pipelines, operations for model repair, flattening, io, optimal orientation, more

### DIFF
--- a/threedframe/cli.py
+++ b/threedframe/cli.py
@@ -313,8 +313,12 @@ def shell(
         "config.setup_solid()",
         f"config.SUPPORT_SCALE = {scale}",
         "from threedframe.scad import *",
-        f"params = JointDirectorParams(model=Path('{model_path}'))",
-        "director = JointDirector(params=params)",
+        "from threedframe.scad import context as scad_context, build as scad_build",
+        f"params = JointDirectorParams.from_model_path(Path('{model_path}'))",
+        "build_ctx = scad_context.BuildContext()",
+        "build_ctx.build_flags ^= scad_context.BuildFlag.LABELS",
+        "director_ctx = scad_build.DirectorContext.from_build_context(build_ctx)",
+        "director = director_ctx.build_strategy(params=params)",
     ]
     if vertex:
         exec_lines.extend(

--- a/threedframe/operations/__init__.py
+++ b/threedframe/operations/__init__.py
@@ -1,0 +1,13 @@
+from .flat import FlatOperation
+from .orient import OptimalOrientOperation
+from .repair import RepairOperation
+from .mesh_io import ReadMeshOperation, WriteMeshOperation, SerializeMeshOperation
+
+__all__ = [
+    "FlatOperation",
+    "RepairOperation",
+    "OptimalOrientOperation",
+    "ReadMeshOperation",
+    "WriteMeshOperation",
+    "SerializeMeshOperation",
+]

--- a/threedframe/operations/flat.py
+++ b/threedframe/operations/flat.py
@@ -1,0 +1,23 @@
+"""Flatten a given mesh.
+
+ Translate the min bound of a given mesh to 0.
+"""
+
+
+from typing import Any
+
+import attrs
+import numpy as np
+import numpy.typing as npt
+
+
+@attrs.define
+class FlatOperation:
+    def _compute_translation(self, vertices: npt.ArrayLike) -> np.ndarray[Any, np.float64]:
+        verts = np.asarray(vertices, dtype=np.float64)
+        min_vert = np.min(axis=0)
+        relative_translation = np.zeros((1, 3), dtype=np.float64) - min_vert
+        return verts + relative_translation
+
+    def operate(self, vertices: npt.ArrayLike) -> np.ndarray[Any, np.float64]:
+        return self._compute_translation(vertices)

--- a/threedframe/operations/flat.py
+++ b/threedframe/operations/flat.py
@@ -4,20 +4,29 @@
 """
 
 
+import copy
 from typing import Any
 
 import attrs
 import numpy as np
+import open3d as o3d
 import numpy.typing as npt
+
+from threedframe.utils import SerializableMesh
 
 
 @attrs.define
 class FlatOperation:
     def _compute_translation(self, vertices: npt.ArrayLike) -> np.ndarray[Any, np.float64]:
         verts = np.asarray(vertices, dtype=np.float64)
-        min_vert = np.min(axis=0)
+        min_vert = verts.min(axis=0)
         relative_translation = np.zeros((1, 3), dtype=np.float64) - min_vert
-        return verts + relative_translation
+        return relative_translation
 
-    def operate(self, vertices: npt.ArrayLike) -> np.ndarray[Any, np.float64]:
-        return self._compute_translation(vertices)
+    def _translate_mesh(self, mesh: o3d.geometry.TriangleMesh) -> o3d.geometry.TriangleMesh:
+        trans = self._compute_translation(mesh.vertices)
+        return mesh.translate(trans.reshape(3, 1))
+
+    def operate(self, mesh: SerializableMesh) -> SerializableMesh:
+        new_mesh = copy.deepcopy(mesh.to_open3d())
+        return SerializableMesh(self._translate_mesh(new_mesh))

--- a/threedframe/operations/mesh_io.py
+++ b/threedframe/operations/mesh_io.py
@@ -75,9 +75,14 @@ class ReadMeshOperation:
 @attrs.define
 class WriteMeshOperation:
     path: Path
+    ascii: bool = attrs.field(default=False)
 
-    def operate(self, mesh: o3d.geometry.TriangleMesh) -> Path:
-        return write_mesh(self.path, mesh)
+    def operate(self, mesh: SerializableMesh) -> Path:
+        _mesh = mesh.to_open3d()
+        _path = write_mesh(self.path, _mesh)
+        if self.ascii:
+            return convert_bin_stl_to_ascii(_path)
+        return _path
 
 
 @attrs.define

--- a/threedframe/operations/mesh_io.py
+++ b/threedframe/operations/mesh_io.py
@@ -1,0 +1,39 @@
+"""IO Operations."""
+
+
+from pathlib import Path
+
+import attrs
+import open3d as o3d
+
+from threedframe.utils import SerializableMesh
+
+
+def write_mesh(path: Path, mesh: o3d.geometry.TriangleMesh) -> Path:
+    o3d.io.write_triangle_mesh(str(path.absolute()), mesh)
+    return path
+
+
+def read_mesh(path: Path) -> o3d.geometry.TriangleMesh:
+    mesh = o3d.io.read_triangle_mesh(str(path.absolute()), enable_post_processing=True)
+    return mesh
+
+
+@attrs.define
+class ReadMeshOperation:
+    def operate(self, path: Path) -> o3d.geometry.TriangleMesh:
+        return read_mesh(path)
+
+
+@attrs.define
+class WriteMeshOperation:
+    path: Path
+
+    def operate(self, mesh: o3d.geometry.TriangleMesh) -> Path:
+        return write_mesh(self.path, mesh)
+
+
+@attrs.define
+class SerializeMeshOperation:
+    def operate(self, mesh: o3d.geometry.TriangleMesh) -> SerializableMesh:
+        return SerializableMesh(mesh)

--- a/threedframe/operations/mesh_io.py
+++ b/threedframe/operations/mesh_io.py
@@ -12,6 +12,8 @@ from threedframe.utils import SerializableMesh
 
 
 def write_mesh(path: Path, mesh: o3d.geometry.TriangleMesh) -> Path:
+    mesh.compute_vertex_normals()
+    mesh.compute_triangle_normals()
     o3d.io.write_triangle_mesh(str(path.absolute()), mesh)
     return path
 

--- a/threedframe/operations/mesh_io.py
+++ b/threedframe/operations/mesh_io.py
@@ -1,6 +1,8 @@
 """IO Operations."""
 
 
+import io
+import struct
 from pathlib import Path
 
 import attrs
@@ -17,6 +19,51 @@ def write_mesh(path: Path, mesh: o3d.geometry.TriangleMesh) -> Path:
 def read_mesh(path: Path) -> o3d.geometry.TriangleMesh:
     mesh = o3d.io.read_triangle_mesh(str(path.absolute()), enable_post_processing=True)
     return mesh
+
+
+def convert_bin_stl_to_ascii(path: Path) -> Path:
+    data = path.read_bytes()
+    out = io.StringIO()
+
+    header = data[:80]
+
+    # Length of Surfaces
+    bin_faces = data[80:84]
+    faces = struct.unpack("I", bin_faces)[0]
+
+    out.write(f"solid {path.stem}")
+
+    for x in range(0, faces):
+        out.write("facet normal ")
+
+        xc = data[84 + x * 50 : (84 + x * 50) + 4]
+        yc = data[88 + x * 50 : (88 + x * 50) + 4]
+        zc = data[92 + x * 50 : (92 + x * 50) + 4]
+
+        out.write(str(struct.unpack("f", xc)[0]) + " ")
+        out.write(str(struct.unpack("f", yc)[0]) + " ")
+        out.write(str(struct.unpack("f", zc)[0]) + "\n")
+
+        out.write(" outer loop\n")
+        for y in range(1, 4):
+            out.write("  vertex ")
+
+            xc = data[84 + y * 12 + x * 50 : (84 + y * 12 + x * 50) + 4]
+            yc = data[88 + y * 12 + x * 50 : (88 + y * 12 + x * 50) + 4]
+            zc = data[92 + y * 12 + x * 50 : (92 + y * 12 + x * 50) + 4]
+
+            out.write(str(struct.unpack("f", xc)[0]) + " ")
+            out.write(str(struct.unpack("f", yc)[0]) + " ")
+            out.write(str(struct.unpack("f", zc)[0]) + "\n")
+
+        out.write(" endloop\n")
+        out.write("endfacet\n")
+
+    out.write(f"endsolid {path.stem}\n")
+
+    path.write_text(out.getvalue())
+    out.close()
+    return path
 
 
 @attrs.define

--- a/threedframe/operations/orient.py
+++ b/threedframe/operations/orient.py
@@ -1,0 +1,38 @@
+"""Auto Orient Operation."""
+
+from __future__ import annotations
+
+import copy
+import tempfile
+from pathlib import Path
+
+import attrs
+import open3d as o3d
+from tweaker3 import FileHandler, MeshTweaker
+
+from threedframe.utils import SerializableMesh
+
+
+@attrs.define
+class OptimalOrientOperation:
+    def _prepare_mesh(self, mesh: o3d.geometry.TriangleMesh) -> list[list[int]]:
+        tmp_file = tempfile.mktemp()
+        o3d.io.write_triangle_mesh(tmp_file, mesh, write_ascii=True)
+        fh = FileHandler.FileHandler()
+        objs: list[dict[str, list[list[int]]]] = fh.load_mesh(tmp_file)
+        _mesh = objs[0]["mesh"]
+        Path.unlink(tmp_file)
+        return _mesh
+
+    def _orient_mesh(
+        self, mesh: o3d.geometry.TriangleMesh, data: list[list[int]]
+    ) -> o3d.geometry.TriangleMesh:
+        tweak = MeshTweaker.Tweak(
+            data, extended_mode=True, verbose=True, show_progress=True, min_volume=False
+        )
+        new_mesh = copy.deepcopy(mesh).rotate(tweak.matrix)
+        return new_mesh
+
+    def operate(self, mesh: SerializableMesh) -> SerializableMesh:
+        _mesh = mesh.to_open3d()
+        return SerializableMesh(self._orient_mesh(_mesh))

--- a/threedframe/operations/orient.py
+++ b/threedframe/operations/orient.py
@@ -11,14 +11,17 @@ import open3d as o3d
 from tweaker3 import FileHandler, MeshTweaker
 
 from threedframe.utils import SerializableMesh
+from threedframe.operations.mesh_io import convert_bin_stl_to_ascii
 
 
 @attrs.define
 class OptimalOrientOperation:
     def _prepare_mesh(self, mesh: o3d.geometry.TriangleMesh) -> list[list[int]]:
         tmp_file = tempfile.mktemp(suffix=".stl")
-        # TODO: apparently o3d doesnt actually support writing stl ascii yet...
-        o3d.io.write_triangle_mesh(tmp_file, mesh, write_ascii=True)
+        mesh.compute_vertex_normals()
+        mesh.compute_triangle_normals()
+        o3d.io.write_triangle_mesh(tmp_file, mesh)
+        convert_bin_stl_to_ascii(Path(tmp_file))
         fh = FileHandler.FileHandler()
         objs: list[dict[str, list[list[int]]]] = fh.load_mesh(tmp_file)
         _mesh = objs[0]["mesh"]

--- a/threedframe/operations/orient.py
+++ b/threedframe/operations/orient.py
@@ -16,12 +16,13 @@ from threedframe.utils import SerializableMesh
 @attrs.define
 class OptimalOrientOperation:
     def _prepare_mesh(self, mesh: o3d.geometry.TriangleMesh) -> list[list[int]]:
-        tmp_file = tempfile.mktemp()
+        tmp_file = tempfile.mktemp(suffix=".stl")
+        # TODO: apparently o3d doesnt actually support writing stl ascii yet...
         o3d.io.write_triangle_mesh(tmp_file, mesh, write_ascii=True)
         fh = FileHandler.FileHandler()
         objs: list[dict[str, list[list[int]]]] = fh.load_mesh(tmp_file)
         _mesh = objs[0]["mesh"]
-        Path.unlink(tmp_file)
+        Path(tmp_file).unlink()
         return _mesh
 
     def _orient_mesh(
@@ -35,4 +36,4 @@ class OptimalOrientOperation:
 
     def operate(self, mesh: SerializableMesh) -> SerializableMesh:
         _mesh = mesh.to_open3d()
-        return SerializableMesh(self._orient_mesh(_mesh))
+        return SerializableMesh(self._orient_mesh(_mesh, self._prepare_mesh(_mesh)))

--- a/threedframe/operations/pipes.py
+++ b/threedframe/operations/pipes.py
@@ -1,0 +1,50 @@
+"""Operation Pipes."""
+from __future__ import annotations
+
+from typing import Union, TypeVar, Protocol, runtime_checkable
+from collections import deque
+
+import attrs
+from loguru import logger
+
+import threedframe.operations as op
+
+TargetT = TypeVar("TargetT")
+
+
+@runtime_checkable
+class Operation(Protocol[TargetT]):
+    def operate(self, mesh: TargetT) -> TargetT:
+        ...
+
+
+@attrs.define
+class OperationPipeline:
+    operations: deque[Union[Operation, OperationPipeline]] = attrs.field(factory=deque)
+
+    def add_ops(self, *ops: Union[Operation[TargetT], OperationPipeline]) -> OperationPipeline:
+        self.operations.extend(ops)
+        return self
+
+    def apply(self, target: TargetT) -> TargetT:
+        result = target
+        for op in self.operations:
+            if isinstance(op, OperationPipeline):
+                result = op.apply(result)
+            if isinstance(op, Operation):
+                logger.info("applying operation: {!r}", op)
+                result = op.operate(result)
+            else:
+                raise TypeError("Expected Operation or OperationPipeline object, got: {}", o)
+        return result
+
+
+OrientPipeline = OperationPipeline().add_ops(
+    op.RepairOperation(),
+    op.FlatOperation(),
+    op.OptimalOrientOperation(),
+)
+
+OrientMeshFilePipeline = lambda path: OperationPipeline().add_ops(
+    op.ReadMeshOperation(), op.SerializeMeshOperation(), OrientPipeline, op.WriteMeshOperation(path)
+)

--- a/threedframe/operations/pipes.py
+++ b/threedframe/operations/pipes.py
@@ -31,11 +31,11 @@ class OperationPipeline:
         for op in self.operations:
             if isinstance(op, OperationPipeline):
                 result = op.apply(result)
-            if isinstance(op, Operation):
+            elif isinstance(op, Operation):
                 logger.info("applying operation: {!r}", op)
                 result = op.operate(result)
             else:
-                raise TypeError("Expected Operation or OperationPipeline object, got: {}", o)
+                raise TypeError(f"Expected Operation or OperationPipeline object, got: {op}")
         return result
 
 

--- a/threedframe/operations/pipes.py
+++ b/threedframe/operations/pipes.py
@@ -46,5 +46,8 @@ OrientPipeline = OperationPipeline().add_ops(
 )
 
 OrientMeshFilePipeline = lambda path: OperationPipeline().add_ops(
-    op.ReadMeshOperation(), op.SerializeMeshOperation(), OrientPipeline, op.WriteMeshOperation(path)
+    op.ReadMeshOperation(),
+    op.SerializeMeshOperation(),
+    OrientPipeline,
+    op.WriteMeshOperation(path),
 )

--- a/threedframe/operations/repair.py
+++ b/threedframe/operations/repair.py
@@ -8,7 +8,7 @@ import open3d as o3d
 from threedframe.utils import SerializableMesh
 
 
-def prepare_mesh(self, mesh: o3d.geometry.TriangleMesh) -> o3d.geometry.TriangleMesh:
+def prepare_mesh(mesh: o3d.geometry.TriangleMesh) -> o3d.geometry.TriangleMesh:
     if not mesh.has_vertex_normals():
         mesh.compute_vertex_normals()
     if not mesh.has_triangle_normals():
@@ -16,8 +16,8 @@ def prepare_mesh(self, mesh: o3d.geometry.TriangleMesh) -> o3d.geometry.Triangle
     return mesh
 
 
-def repair_mesh(self, mesh: o3d.geometry.TriangleMesh) -> o3d.geometry.TriangleMesh:
-    new_mesh = self._prepare_mesh(copy.deepcopy(mesh))
+def repair_mesh(mesh: o3d.geometry.TriangleMesh) -> o3d.geometry.TriangleMesh:
+    new_mesh = prepare_mesh(copy.deepcopy(mesh))
     new_mesh.remove_duplicated_vertices()
     new_mesh.remove_unreferenced_vertices()
     new_mesh.remove_duplicated_triangles()

--- a/threedframe/operations/repair.py
+++ b/threedframe/operations/repair.py
@@ -23,6 +23,8 @@ def repair_mesh(mesh: o3d.geometry.TriangleMesh) -> o3d.geometry.TriangleMesh:
     new_mesh.remove_duplicated_triangles()
     new_mesh.remove_degenerate_triangles()
     new_mesh.remove_non_manifold_edges()
+    new_mesh.compute_vertex_normals()
+    new_mesh.compute_triangle_normals()
     return new_mesh
 
 

--- a/threedframe/operations/repair.py
+++ b/threedframe/operations/repair.py
@@ -1,0 +1,33 @@
+"""Repair Operation"""
+
+import copy
+
+import attrs
+import open3d as o3d
+
+from threedframe.utils import SerializableMesh
+
+
+def prepare_mesh(self, mesh: o3d.geometry.TriangleMesh) -> o3d.geometry.TriangleMesh:
+    if not mesh.has_vertex_normals():
+        mesh.compute_vertex_normals()
+    if not mesh.has_triangle_normals():
+        mesh.compute_triangle_normals()
+    return mesh
+
+
+def repair_mesh(self, mesh: o3d.geometry.TriangleMesh) -> o3d.geometry.TriangleMesh:
+    new_mesh = self._prepare_mesh(copy.deepcopy(mesh))
+    new_mesh.remove_duplicated_vertices()
+    new_mesh.remove_unreferenced_vertices()
+    new_mesh.remove_duplicated_triangles()
+    new_mesh.remove_degenerate_triangles()
+    new_mesh.remove_non_manifold_edges()
+    return new_mesh
+
+
+@attrs.define
+class RepairOperation:
+    def operate(self, mesh: SerializableMesh) -> SerializableMesh:
+        _mesh = repair_mesh(mesh.to_open3d())
+        return SerializableMesh(_mesh)

--- a/threedframe/scad/build.py
+++ b/threedframe/scad/build.py
@@ -26,11 +26,11 @@ ScadT = TypeVar("ScadT", bound="ScadMeta")
 
 
 @attrs.define
-class DirectorContext:
-    context: Context
+class DirectorContext(Context["JointDirectorParams"]):
     strategy: Type[JointDirector]
+    context: Context = attrs.field(repr=False)
 
-    joint_context: Context = attrs.field(default=None)
+    joint_context: JointContext = attrs.field(default=None)
 
     @property
     def flags(self) -> BuildFlag:
@@ -104,9 +104,9 @@ class JointDirectorParams(BaseModel):
 
 @attrs.define
 class JointDirector:
-    context: DirectorContext
-    params: JointDirectorParams
-    joints: Dict["ModelVertex", "JointMeta"] = attrs.field(factory=dict)
+    context: DirectorContext = attrs.field(repr=False)
+    params: JointDirectorParams = attrs.field(repr=False)
+    joints: Dict["ModelVertex", "JointMeta"] = attrs.field(factory=dict, repr=False)
     scad_paths: Dict["ModelVertex", Path] = attrs.field(factory=dict)
     render_paths: Dict["ModelVertex", Path] = attrs.field(factory=dict)
 

--- a/threedframe/scad/build.py
+++ b/threedframe/scad/build.py
@@ -17,6 +17,7 @@ from threedframe.models import ModelData, ModelVertex
 from threedframe.constant import RenderFileType
 from threedframe.scad.joint import JointParams, JointContext
 from threedframe.scad.context import Context, BuildFlag
+from threedframe.operations.pipes import OrientMeshFilePipeline
 
 if TYPE_CHECKING:
     from .interfaces import ScadMeta, JointMeta
@@ -153,6 +154,7 @@ class JointDirector:
         for line in iter(proc.stderr.readline, b""):
             outline = line.decode().rstrip("\n")
             logger.debug("[OpenSCAD]: {}", outline)
+        OrientMeshFilePipeline(out_path).apply(out_path)
 
     def preview_joint(self, vertex: "ModelVertex"):
         rnd_path = self.render_paths[vertex]

--- a/threedframe/scad/build.py
+++ b/threedframe/scad/build.py
@@ -128,7 +128,6 @@ class JointDirector:
     def build_joint(self, vertex: "ModelVertex") -> Optional["JointMeta"]:
         logger.info("Building joint for vertex: {}", vertex.vidx)
         joint = self.create_joint(vertex=vertex)
-        joint.assemble()
         self.write_joint(joint)
         return joint
 

--- a/threedframe/scad/core.py
+++ b/threedframe/scad/core.py
@@ -22,8 +22,8 @@ if TYPE_CHECKING:
 
 @attrs.define
 class CoreContext(Context[CoreParametersBase]):
-    context: Context
     strategy: Type[CoreMeta]
+    context: Context = attrs.field(repr=False)
 
     label_context: LabelContext = attrs.field(default=None)
 

--- a/threedframe/scad/fixture.py
+++ b/threedframe/scad/fixture.py
@@ -28,8 +28,8 @@ from threedframe.scad.interfaces import FixtureMeta, scad_timer
 
 @attrs.define
 class FixtureContext(Context["FixtureParams"]):
-    context: Context
     strategy: Type[FixtureMeta]
+    context: Context = attrs.field(repr=False)
 
     label_context: LabelContext = attrs.field(default=None)
 

--- a/threedframe/scad/joint.py
+++ b/threedframe/scad/joint.py
@@ -27,8 +27,8 @@ from threedframe.scad.interfaces import JointMeta, FixtureMeta, JointParamsMeta,
 
 @attrs.define
 class JointContext(Context["JointParams"]):
-    context: Context
     strategy: Type[JointMeta]
+    context: Context = attrs.field(repr=False)
 
     fixture_context: FixtureContext = attrs.field(default=None)
     core_context: CoreContext = attrs.field(default=None)

--- a/threedframe/scad/joint.py
+++ b/threedframe/scad/joint.py
@@ -93,7 +93,7 @@ class Joint(JointMeta):
             def on_mesh(fixture_name: str, mesh_result: FixtureMesh):
                 """collect task results and store by fixture name."""
                 logger.info("recieved mesh result: {}", mesh_result)
-                o3d_mesh = mesh_result.mesh.to_open3d(do_compute=True)
+                o3d_mesh = mesh_result.mesh.to_open3d()
                 fixtures_by_name[fixture_name].meshes[mesh_result.mesh_type] = o3d_mesh
 
             for fix in fixtures:


### PR DESCRIPTION
- feat(utils): extend SerializableMesh eigen supported attrs
- feat(cli): update shell cmd setup
- fix(scad): update serializable mesh to o3d ref
- fix(scad): prevent infinite recursions due to recursive contexts included in reprs
- fix(build): maybe dont rebuild each joint twice for no reason
- feat(ops): add FlatOperation for aligning a given mesh's z-axis with origin
- feat(ops): add operation for repairing mesh non-manifold edges/vertices and other
- feat(ops): add optimal-orient operation for applying an optimally computed rotation matrix to mesh
- fix(ops): update flat operation to follow op protocol
- feat(ops): add mesh io operations
- fix(ops): bad arguments in repair ops
- fix(ops): bad args in orient op, add todo to figure out o3d ascii write
- feat(ops): add Operation protocol, OperationPipeline and OrientMesh/File pipelines
- feat(scad): execute orient mesh file pipeline post render
